### PR TITLE
08 ユーザーの詳細ページに投稿一覧を表示する

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -98,3 +98,24 @@ img {
 .pagination {
   justify-content: center;
 }
+
+
+.thumbs {
+  width: 100%;
+  position: relative;
+  display: block;
+
+  &::before {
+    content: "";
+    display: block;
+    padding-top: 100%;
+  }
+
+  img {
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    object-fit: cover;
+  }
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,6 +21,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(params[:id])
+    @posts = @user.posts
   end
 
   private

--- a/app/views/posts/_thumbnail_post.html.slim
+++ b/app/views/posts/_thumbnail_post.html.slim
@@ -1,0 +1,3 @@
+.col-md-4.mb-3
+  = link_to post_path(thumbnail_post), class: 'thumbs' do
+    = image_tag thumbnail_post.pictures.first.url

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -12,7 +12,7 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-white
         a.nav-link href="#"
           = icon 'far', 'heart', class: 'fa-lg'
       li.nav-item
-        a.nav-link href="#"
+        = link_to user_path(current_user), class: 'nav-link' do
           = icon 'far', 'user', class: 'fa-lg'
       li.nav-item
         = link_to 'ログアウト', logout_path, class: 'nav-link', method: :delete

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,6 +1,6 @@
 .container
   .row
-    .col-md-6.offset-md-3
+    .col-md-10.offset-md-1
       .card
         .card-body
           .text-center.mb-3
@@ -9,3 +9,6 @@
             = @user.username
           .text-center
             = render 'follow_area', user: @user
+          hr
+          .row
+            = render partial: 'posts/thumbnail_post', collection: @posts


### PR DESCRIPTION
## 概要

ユーザーの詳細ページに同ユーザーの投稿を一覧表示させてください。

- タイル表示させる
- ヘッダーのユーザーアイコンに自分のユーザー詳細ページへのリンクを設定してさせる

## コメント
「rails タイル表示」でググるとjQuery Masonryってやつを使って実装するやり方が出てきましたが、難しそうだったので解答例に習いました。
解答例のscssの記述ですが
```
.thumbs {
  width: 100%;
  position: relative;
  display: block;

  &::before {
    content: "";
    display: block;
    padding-top: 100%;
  }

  img {
    width: 100%;
    height: 100%;
    position: absolute;
    top: 0;
    object-fit: cover;
  }
}
```
とありますが、&::beforeの疑似要素？なるものが何をやっているのか、これがどう働いてタイル表示になっているかなどよくわかっていないのでそのあたりを聞きたいです。